### PR TITLE
Fix quote escaping in CSV generator

### DIFF
--- a/getData.js
+++ b/getData.js
@@ -38,10 +38,15 @@ copy(
         // Include original UUID filename in the description
         const fullDescription = `Original filename: ${uuid}.mp3\n\nPrompt:\n${description}`;
 
-        // Always wrap description in quotes for consistency, and ensure no trailing newline
+        // Escape double quotes for CSV and remove any trailing newline
+        const escapedDescription = fullDescription
+          .replace(/"/g, '""')
+          .replace(/\n$/, "");
+
+        // Always wrap description in quotes for consistency
         return `${formattedTitle}.mp3,${
           x.value.audio_url
-        },"${fullDescription.replace(/\n$/, "")}"`;
+        },"${escapedDescription}"`;
       }),
   ]
     .join("\n")


### PR DESCRIPTION
## Summary
- fix CSV generation in getData.js so prompts containing quotes do not break parsing

## Testing
- `python3 -m py_compile suno-downloader.py`
- `node -c getData.js`


------
https://chatgpt.com/codex/tasks/task_e_687afd824b54832b870d8f36dec62374